### PR TITLE
Potential fix for code scanning alert no. 42: Query built from user-controlled sources

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/sqlinjection/mitigation/Servers.java
+++ b/src/main/java/org/owasp/webgoat/lessons/sqlinjection/mitigation/Servers.java
@@ -49,12 +49,17 @@ public class Servers {
   public List<Server> sort(@RequestParam String column) throws Exception {
     List<Server> servers = new ArrayList<>();
 
+    // List of allowed column names
+    List<String> allowedColumns = List.of("id", "hostname", "ip", "mac", "status", "description");
+
+    // Validate the column parameter
+    if (!allowedColumns.contains(column)) {
+      throw new IllegalArgumentException("Invalid column name: " + column);
+    }
+
     try (var connection = dataSource.getConnection()) {
-      try (var statement =
-          connection.prepareStatement(
-              "select id, hostname, ip, mac, status, description from SERVERS where status <> 'out"
-                  + " of order' order by "
-                  + column)) {
+      String query = "select id, hostname, ip, mac, status, description from SERVERS where status <> 'out of order' order by " + column;
+      try (var statement = connection.prepareStatement(query)) {
         try (var rs = statement.executeQuery()) {
           while (rs.next()) {
             Server server =


### PR DESCRIPTION
Potential fix for [https://github.com/BUCEIT/UCM_WebGoat/security/code-scanning/42](https://github.com/BUCEIT/UCM_WebGoat/security/code-scanning/42)

To fix the problem, we should avoid using string concatenation to build the SQL query. Instead, we can use a prepared statement with a parameterized query. However, since the `column` parameter represents a column name and cannot be parameterized directly in a prepared statement, we need to validate the `column` parameter against a whitelist of allowed column names before constructing the query.

1. Create a list of allowed column names.
2. Validate the `column` parameter against this list.
3. If the `column` parameter is valid, construct the query using the validated column name.
4. If the `column` parameter is not valid, throw an exception or handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
